### PR TITLE
Disable nginx server_tokens to minimize info leak

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,4 +35,6 @@ server {
   open_file_cache_valid 30s;
   open_file_cache_min_uses 2;
   open_file_cache_errors on;
+
+  server_tokens off;
 }


### PR DESCRIPTION
This can help reduce server information leak :)

Before:
```
$ curl -sI http://lxc.im/ | grep ^Server:
Server: nginx/1.14.2
```

After:
```
$ curl -sI http://lxc.im/ | grep ^Server:
Server: nginx
```